### PR TITLE
QUICKFIX: changed to rmw-microxrcedds to a fixed commit hash

### DIFF
--- a/microros_utils/repositories.py
+++ b/microros_utils/repositories.py
@@ -29,6 +29,9 @@ class Repository:
         # TODO(pablogs) ensure that git is installed
         if os.path.exists(self.path):
             command = f"cd {self.path} && git pull {self.url} {self.branch}"
+            if (self.name == "rmw-microxrcedds") :
+                command = f"cd {self.path} && git pull {self.url} {self.branch} && git reset --hard c31887f38c708f085d4a2117e47055e0176acc1e"
+                print(command)
             result = run_cmd(command)
             if 0 != result.returncode:
                 print(f"{self.name} pull failed: \n{result.stderr.decode('utf-8')}")

--- a/microros_utils/repositories.py
+++ b/microros_utils/repositories.py
@@ -29,9 +29,10 @@ class Repository:
         # TODO(pablogs) ensure that git is installed
         if os.path.exists(self.path):
             command = f"cd {self.path} && git pull {self.url} {self.branch}"
+            print(command)
             if (self.name == "rmw-microxrcedds") :
                 command = f"cd {self.path} && git pull {self.url} {self.branch} && git reset --hard c31887f38c708f085d4a2117e47055e0176acc1e"
-                print(command)
+                #print(command)
             result = run_cmd(command)
             if 0 != result.returncode:
                 print(f"{self.name} pull failed: \n{result.stderr.decode('utf-8')}")

--- a/microros_utils/repositories.py
+++ b/microros_utils/repositories.py
@@ -29,10 +29,6 @@ class Repository:
         # TODO(pablogs) ensure that git is installed
         if os.path.exists(self.path):
             command = f"cd {self.path} && git pull {self.url} {self.branch}"
-            print(command)
-            if (self.name == "rmw-microxrcedds") :
-                command = f"cd {self.path} && git pull {self.url} {self.branch} && git reset --hard c31887f38c708f085d4a2117e47055e0176acc1e"
-                #print(command)
             result = run_cmd(command)
             if 0 != result.returncode:
                 print(f"{self.name} pull failed: \n{result.stderr.decode('utf-8')}")
@@ -40,6 +36,9 @@ class Repository:
             return
 
         command = "git clone -b {} {} {}".format(self.branch, self.url, self.path)
+        if (self.name == "rmw-microxrcedds") :
+                command = "git clone -b {} {} {} && cd {} && git reset --hard c31887f38c708f085d4a2117e47055e0176acc1e".format(self.branch, self.url, self.path,self.path)
+                print(command)
         result = run_cmd(command)
 
         if 0 != result.returncode:


### PR DESCRIPTION
QUICKFIX: Temporarily fixed the issue by locking rmw-microxrcedds to a specific commit hash. Prior to this fix, the PlatformIO micro-ROS build succeeded, but after flashing to the MCU, no node was running. This workaround is intended as a temporary measure until a proper solution is implemented.